### PR TITLE
@guly: check if http_proxy is configured, mainly used for apt-cacher-ng

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -126,6 +126,11 @@ if [ -n "$OPT_pu" ]; then
 	KALI_DIST="$KALI_DIST+pu"
 fi
 
+# helper for apt-cacher-ng
+if [ -n "$http_proxy" ]; then
+  KALI_CONFIG_OPTS="$KALI_CONFIG_OPTS --apt-http-proxy $http_proxy"
+fi
+
 # Set sane PATH (cron seems to lack /sbin/ dirs)
 export PATH="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
 


### PR DESCRIPTION
check if http_proxy env variable is configured, mainly used for apt-cacher-ng